### PR TITLE
Fix `NoMethodError (undefined method `for_replicate' for nil)`

### DIFF
--- a/lib/replicate/active_record.rb
+++ b/lib/replicate/active_record.rb
@@ -167,7 +167,8 @@ module Replicate
           if reflection.macro == :has_and_belongs_to_many
             dump_has_and_belongs_to_many_replicant(dumper, reflection)
           end
-          __send__(reflection.name).reset # clear to allow GC
+          # clear to allow GC
+          __send__(reflection.name).reset if __send__(reflection.name).respond_to?(:reset)
         else
           warn "error: #{self.class}##{association} is invalid"
         end


### PR DESCRIPTION
Running `script/replicate-user yancey` raises error `lib/replicate/active_record.rb:170:in `dump_association_replicants': undefined method `reset' for nil:NilClass (NoMethodError)`.

That should fix it.